### PR TITLE
Cleaning up the unveil() calls.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Building / Installation
 [autoconf](https://www.gnu.org/software/autoconf/) and
 [automake](https://www.gnu.org/software/automake/).
 
-To install `mcds` with the default options:
+To install `mcds` with the default options (this includes GPGME support):
 
     ./configure
     make

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@
 #
 
 AC_PREREQ(2.61)
-AC_INIT([mcds], [1.2], [tbrown@freeshell.org])
+AC_INIT([mcds], [1.3], [tbrown@freeshell.org])
 AC_CONFIG_AUX_DIR([build-aux])
 
 # Define our M4 macro directory
@@ -27,6 +27,7 @@ AC_CONFIG_HEADERS([src/config.h])
 AX_COMPILER_VENDOR
 AC_PROG_CC
 AC_PROG_CC_STDC
+AC_PROG_AWK
 
 # Checks for header files
 AC_HEADER_STDC
@@ -50,20 +51,26 @@ AC_CONFIG_FILES([Makefile
 PKG_CHECK_MODULES([CURL], [libcurl])
 PKG_CHECK_MODULES([XML], [libxml-2.0])
 
-dnl locate gpgme
+dnl locate gpgme and gpg
+AH_TEMPLATE([GPGME_CONFIG], [Defined to the full path of gpgme-config])
+AH_TEMPLATE([GPG_CONFIG], [Defined to the full path of gpgconf])
+AH_TEMPLATE([GPG], [Defined to the full path of gpg/gpg2])
 AC_ARG_ENABLE([gpgme],
         AS_HELP_STRING([--disable-gpgme],[do not use GPGME support]))
 AS_IF([test x$enable_gpgme != xno],
-      [m4_ifdef([AM_PATH_GPGME],
-                [AM_PATH_GPGME([],
-                               [AC_DEFINE(HAVE_GPGME, 1, [GPGME support])
-                                AM_CONDITIONAL([WANT_GPGME], [test x = x])
-                               ],
-                               [AC_MSG_ERROR([GPGME not found])])
-                ],
-                [AC_MSG_ERROR([GPGME not found])])
+      [AM_PATH_GPGME([],
+                     [AC_DEFINE([HAVE_GPGME], [1], [Define to 1 if you have GPGME support])
+                      AM_CONDITIONAL([WANT_GPGME], [test x = x])
+                     ],
+                     [AC_MSG_ERROR([GPGME not found])])
+      AC_DEFINE_UNQUOTED([GPGME_CONFIG], ["$GPGME_CONFIG"])
+      AC_PATH_PROGS([GPG_CONFIG], [gpgconf], [])
+      AC_DEFINE_UNQUOTED([GPG_CONFIG], ["$GPG_CONFIG"])
+      GPG=$(eval $GPG_CONFIG | $AWK -F: '{if ($[]1 == "gpg") {print $[]NF}}')
+      AC_DEFINE_UNQUOTED([GPG], ["$GPG"])
+      enable_gpgme=yes
       ],
-      [AC_DEFINE(HAVE_GPGME, 0, [GPGME not supported])
+      [AC_DEFINE(HAVE_GPGME, 0, [Define to 1 if you have GPGME support])
        AM_CONDITIONAL([WANT_GPGME], [test x = y])]
 )
 
@@ -80,4 +87,5 @@ echo "Installation prefix        : $prefix"
 echo "C compiler                 : $ax_cv_c_compiler_vendor"
 echo "C command                  : $CC $CFLAGS"
 echo "Linker                     : $LD $LDFLAGS $LIBS"
+echo "Enable GPGME               : $enable_gpgme"
 echo

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -4,6 +4,15 @@
    language is requested. */
 #undef ENABLE_NLS
 
+/* Defined to the full path of gpg/gpg2 */
+#undef GPG
+
+/* Defined to the full path of gpgme-config */
+#undef GPGME_CONFIG
+
+/* Defined to the full path of gpgconf */
+#undef GPG_CONFIG
+
 /* Define to 1 if you have the Mac OS X function CFLocaleCopyCurrent in the
    CoreFoundation framework. */
 #undef HAVE_CFLOCALECOPYCURRENT
@@ -22,7 +31,7 @@
 /* Define if the GNU gettext() function is already present or preinstalled. */
 #undef HAVE_GETTEXT
 
-/* GPGME not supported */
+/* Define to 1 if you have GPGME support */
 #undef HAVE_GPGME
 
 /* Define if you have the iconv() function and it works. */

--- a/src/curl.c
+++ b/src/curl.c
@@ -84,7 +84,6 @@ cinit(CURL **hdl)
 			warnx(_("Unable to set curls password option."));
 			return(EXIT_FAILURE);
 		}
-
 	} else {
 		if (curl_easy_setopt(*hdl, CURLOPT_NETRC, options.netrc)) {
 			warnx(_("Unable to set curls .netrc option."));

--- a/src/decrypt.c
+++ b/src/decrypt.c
@@ -65,6 +65,21 @@ decrypt(char *filename)
 	gpgme_data_t out = {0};  /* GPGME decrypted output */
 	char tmp[LINE_MAX];      /* GPGME data read */
 
+#ifdef HAVE_UNVEIL
+	if (unveil(GPGME_CONFIG, "rx") == -1) {
+		warn(_("Unable to unveil %s"), GPGME_CONFIG);
+		return(EXIT_FAILURE);
+	}
+	if (unveil(GPG_CONFIG, "rx") == -1) {
+		warn(_("Unable to unveil %s"), GPG_CONFIG);
+		return(EXIT_FAILURE);
+	}
+	if (unveil(GPG, "rx") == -1) {
+		warn(_("Unable to unveil %s"), GPG);
+		return(EXIT_FAILURE);
+	}
+#endif
+
 	gpgme_check_version(NULL);
 	if ((err = gpgme_engine_check_version(GPGME_PROTOCOL_OpenPGP)) != 0) {
 		warnx(_("Unable to initalize GPGME: %s"), gpgme_strerror(err));

--- a/src/mcds.1
+++ b/src/mcds.1
@@ -28,6 +28,7 @@
 .Nd mutt CardDAV query
 .Sh SYNOPSIS
 .Nm
+.Op Fl c Ar config_file
 .Op Fl hVv
 .Op Fl q Cm a | e | n | t
 .Op Fl s Cm a | e | n | t
@@ -42,6 +43,9 @@ It's primary function is to provide an address query command for
 .Pp
 The options are as follows:
 .Bl -tag -width Ds
+.It Fl c Pa config_file
+Specifies an alternative configuration file. The default file is
+.Pa ~/.mcdsrc .
 .It Fl h
 Print help text to standard output and exit.
 .It Fl q Cm a | e | n | t
@@ -109,6 +113,11 @@ file.
 Disabled by default.
 .It Cm username No \&= Ar USERNAME
 The username to login to the CardDAV server with.
+If a username is specified
+.Nm
+will not use the
+.Pa ~/.netrc
+file.
 .It Cm password_file No \&= Ar password.gpg
 The GPG encrypted file containg the password for the CardDAV server.
 .El

--- a/src/rc.h
+++ b/src/rc.h
@@ -33,7 +33,7 @@ extern "C"
 #endif
 
 /** Read the rc file */
-int read_rc(void);
+int read_rc(const char *);
 
 #ifdef __cplusplus
 }                               /* extern "C" */


### PR DESCRIPTION
Cleaning up and tightening the calls to unveil(). GPGME seems
to just fork exec of `gpgme-conf`, `gpgconf` and `gpg`. So we
now find their exact paths in the configuration stage and unveil
them.