### PR TITLE
I386

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -61,27 +61,33 @@ AH_TEMPLATE([GPG], [Defined to the full path of gpg/gpg2])
 AC_ARG_ENABLE([gpgme],
         AS_HELP_STRING([--disable-gpgme], [do not use GPGME support]))
 
-AS_IF([test x$enable_gpgme != xno],
-      [AM_PATH_GPGME([],
-                     [AC_DEFINE([HAVE_GPGME], [1], [Define to 1 if you have GPGME support])
-                      AM_CONDITIONAL([WANT_GPGME], [test x = x])
-                     ],
-                     [AC_MSG_ERROR([GPGME not found, if you do not want GPGME support, rerun with --disable-gpgme])])
-       AC_DEFINE_UNQUOTED([GPGME_CONFIG], ["$GPGME_CONFIG"])
-       AC_PATH_PROG([GPG_CONFIG], [gpgconf])
-       AS_IF([test x$GPG_CONFIG != x],
-             [AC_DEFINE_UNQUOTED([GPG_CONFIG], ["$GPG_CONFIG"])],
-             [AC_MSG_ERROR([gpgconf is needed with GPGME])]
-       )
-       AC_PATH_PROGS([GPG], [gpg gpg2])
-       AS_IF([test x$GPG != x],
-             [AC_DEFINE_UNQUOTED([GPG], ["$GPG"])],
-             [AC_MSG_ERROR([gpg or gpg2 is needed with GPGME])]
-       )
-       enable_gpgme=yes
-      ],
-      [AC_DEFINE(HAVE_GPGME, 0, [Define to 1 if you have GPGME support])
-       AM_CONDITIONAL([WANT_GPGME], [test x = y])]
+m4_ifdef([AM_PATH_GPGME],
+         [AS_IF([test x$enable_gpgme != xno],
+                [AM_PATH_GPGME([],
+                               [AC_DEFINE([HAVE_GPGME], [1], [Define to 1 if you have GPGME support])
+                                AM_CONDITIONAL([WANT_GPGME], [test x = x])
+                               ],
+                               [AC_MSG_ERROR([GPGME not found, if you do not want GPGME support, rerun with --disable-gpgme])])
+                 AC_DEFINE_UNQUOTED([GPGME_CONFIG], ["$GPGME_CONFIG"])
+                 AC_PATH_PROG([GPG_CONFIG], [gpgconf])
+                 AS_IF([test x$GPG_CONFIG != x],
+                       [AC_DEFINE_UNQUOTED([GPG_CONFIG], ["$GPG_CONFIG"])],
+                       [AC_MSG_ERROR([gpgconf is needed with GPGME])]
+                 )
+                 AC_PATH_PROGS([GPG], [gpg gpg2])
+                 AS_IF([test x$GPG != x],
+                       [AC_DEFINE_UNQUOTED([GPG], ["$GPG"])],
+                       [AC_MSG_ERROR([gpg or gpg2 is needed with GPGME])]
+                 )
+                 enable_gpgme=yes
+                ],
+                [AC_DEFINE(HAVE_GPGME, 0, [Define to 1 if you have GPGME support])
+                 AM_CONDITIONAL([WANT_GPGME], [test x = y])]
+          )],
+          [AC_DEFINE(HAVE_GPGME, 0, [Define to 1 if you have GPGME support])
+           AM_CONDITIONAL([WANT_GPGME], [test x = y])
+           enable_gpgme=no
+          ]
 )
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@
 #
 
 AC_PREREQ(2.61)
-AC_INIT([mcds], [1.5], [tbrown@freeshell.org])
+AC_INIT([mcds], [1.6], [tbrown@freeshell.org])
 AC_CONFIG_AUX_DIR([build-aux])
 
 # Define our M4 macro directory
@@ -27,6 +27,9 @@ AC_CONFIG_HEADERS([src/config.h])
 AX_COMPILER_VENDOR
 AC_PROG_CC
 AC_PROG_CC_STDC
+
+# GPGME is compiled with _FILE_OFFSET_BITS=64 on i386
+AC_SYS_LARGEFILE
 
 # Checks for header files
 AC_HEADER_STDC

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -80,6 +80,9 @@
 /* Define to 1 if you have the `unveil' function. */
 #undef HAVE_UNVEIL
 
+/* Define to 1 if your C compiler doesn't accept -c and -o together. */
+#undef NO_MINUS_C_MINUS_O
+
 /* Name of package */
 #undef PACKAGE
 

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -107,5 +107,16 @@
 /* Version number of package */
 #undef VERSION
 
+/* Enable large inode numbers on Mac OS X 10.5.  */
+#ifndef _DARWIN_USE_64_BIT_INODE
+# define _DARWIN_USE_64_BIT_INODE 1
+#endif
+
+/* Number of bits in a file offset, on hosts where this is settable. */
+#undef _FILE_OFFSET_BITS
+
+/* Define for large files, on AIX-style hosts. */
+#undef _LARGE_FILES
+
 /* Define to rpl_malloc if the replacement function should be used. */
 #undef malloc


### PR DESCRIPTION
Adding a autotool check to see if we need to enable large file support for GPGME.
This address bug report #12 .
Also adding `m4_ifdef` around the `AM_PATH_GPGME` check for systems that do not have this macro.