### PR TITLE
Remove obsolete autoconf macros

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -26,13 +26,11 @@ AC_CONFIG_HEADERS([src/config.h])
 # Checks the compiler vendor
 AX_COMPILER_VENDOR
 AC_PROG_CC
-AC_PROG_CC_STDC
 
 # GPGME is compiled with _FILE_OFFSET_BITS=64 on i386
 AC_SYS_LARGEFILE
 
 # Checks for header files
-AC_HEADER_STDC
 AC_CHECK_HEADERS([stdlib.h string.h unistd.h])
 
 # Checks for functions and libraries


### PR DESCRIPTION
### Issue

autoconf-3.71 reports the use of obsolete macros

```
configure.ac:29: warning: The macro `AC_PROG_CC_STDC' is obsolete.
configure.ac:29: You should run autoupdate.
./lib/autoconf/c.m4:1666: AC_PROG_CC_STDC is expanded from...
configure.ac:29: the top level
configure.ac:35: warning: The macro `AC_HEADER_STDC' is obsolete.
configure.ac:35: You should run autoupdate.
./lib/autoconf/headers.m4:704: AC_HEADER_STDC is expanded from...
```

This is not an issue with autoconf-3.69.

### Fix

Removing these macros results in a clear run with autoconf-3.71.

### Caveat

I am not an expert in the autoconf ecosystem!