### PR TITLE
Fix spelling errors identified by lintian

### DIFF
--- a/src/decrypt.c
+++ b/src/decrypt.c
@@ -82,7 +82,7 @@ decrypt(char *filename)
 
 	gpgme_check_version(NULL);
 	if ((err = gpgme_engine_check_version(GPGME_PROTOCOL_OpenPGP)) != 0) {
-		warnx(_("Unable to initalize GPGME: %s"), gpgme_strerror(err));
+		warnx(_("Unable to initialize GPGME: %s"), gpgme_strerror(err));
 		return(EXIT_FAILURE);
 	}
 

--- a/src/mcds.1
+++ b/src/mcds.1
@@ -119,7 +119,7 @@ will not use the
 .Pa ~/.netrc
 file.
 .It Cm password_file No \&= Ar password.gpg
-The GPG encrypted file containg the password for the CardDAV server.
+The GPG encrypted file containing the password for the CardDAV server.
 .El
 .It Pa ~/.netrc
 Used to access your username and password when authenticating with the


### PR DESCRIPTION
When building a debian package, these typos were identified.

### Errors

```
I: mcds: typo-in-manual-page containg containing [usr/share/man/man1/mcds.1.gz:122]
I: mcds: spelling-error-in-binary initalize initialize [usr/bin/mcds]
```

### Fix

Eliminates these notices from Lintian.

These are not blocking failures but eliminating noise helps.