### PR TITLE
Eliminate some gcc warnings

### DIFF
--- a/src/rc.c
+++ b/src/rc.c
@@ -117,15 +117,11 @@ read_rc(const char *file)
 		++ln;
 		lptr = line;
 		i = 0;
-		while ((tmp = strsep(&lptr, " \t=")) != NULL) {
+		while ((tmp = strsep(&lptr, " \t\n=")) != NULL) {
 			if (tmp[0] != '\0') {
 				len = strlen(tmp);
 				vals[i] = xmalloc(len +1);
-				if (tmp[len-1] == '\n') {
-					strncpy(vals[i], tmp, len-1);
-				} else {
-					strncpy(vals[i], tmp, len);
-				}
+				strncpy(vals[i], tmp, len +1);
 				++i;
 				if (i == 2) {
 					break;


### PR DESCRIPTION
[ edit: as revised, this PR fixes #23 ]

Eliminate some warnings found with gcc-13.2.

### `-Wformat`

```
gcc -DLOCALEDIR=\"/usr/share/locale\" -DHAVE_CONFIG_H   -I/usr/include/i386-linux-gnu  -I/usr/include/libxml2   -Wdate-time -D_FORTIFY_SOURCE=2  -g -O2 -Werror=implicit-function-declaration -ffile-prefix-map=/builds/abower/mcds/debian/output/source_dir=. -fstack-protector-strong -Wformat -Werror=format-security -Wall -pedantic -c -o mcds-mem.o 'test -f 'mem.c' || echo './''mem.c
In file included from gettext.h:26,
                 from mem.c:35:
mem.c: In function 'xmalloc':
mem.c:60:24: warning: format '%ld' expects argument of type 'long int', but argument 3 has type 'size_t' {aka 'unsigned int'} [-Wformat=]
   60 |     errx(EX_SOFTWARE,_("out of memory (unable to allocate %ld bytes)"), n);
      |                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
mem.c:60:22: note: in expansion of macro '_'
   60 |     errx(EX_SOFTWARE,_("out of memory (unable to allocate %ld bytes)"), n);
      |                      ^
mem.c:60:61: note: format string is defined here
   60 |     errx(EX_SOFTWARE,_("out of memory (unable to allocate %ld bytes)"), n);
      |                                                           ~~^
      |                                                             |
      |                                                             long int
      |                                                           %d
```

### `-Wunused-variable`

```
gcc -DLOCALEDIR=\"/usr/share/locale\" -DHAVE_CONFIG_H   -I/usr/include/i386-linux-gnu  -I/usr/include/libxml2   -Wdate-time -D_FORTIFY_SOURCE=2  -g -O2 -Werror=implicit-function-declaration -ffile-prefix-map=/builds/abower/mcds/debian/output/source_dir=. -fstack-protector-strong -Wformat -Werror=format-security -Wall -pedantic -c -o mcds-rc.o `test -f 'rc.c' || echo './'`rc.c
rc.c: In function 'read_rc':
rc.c:75:27: warning: unused variable 'nfile' [-Wunused-variable]
   75 |         static const char nfile[] = ".netrc";  /* Netrc file */
      |                           ^~~~~
```

### `-Wstringop-trunctation`

```
rc.c:127:41: warning: '__builtin_strncpy' output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
  127 |                                         strncpy(vals[i], tmp, len);
      |                                         ^
rc.c:122:39: note: length computed here
  122 |                                 len = strlen(tmp);
      |                                       ^~~~~~~~~~~
```