### PR TITLE
Parse config and handle -h/-V before reading password file

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -47,6 +47,7 @@
 
 #include "defs.h"
 #include "options.h"
+#include "decrypt.h"
 #include "mem.h"
 #include "rc.h"
 #include "curl.h"
@@ -119,6 +120,11 @@ main(int argc, char **argv)
 		}
 	}
 
+	if (options.password_file &&
+	    decrypt(options.password_file)) {
+		return(EXIT_FAILURE);
+	}
+
 #ifdef HAVE_UNVEIL
 	if (unveil(NULL, NULL) == -1) {
 		warn(_("Unable to disable further unveil"));
@@ -161,6 +167,10 @@ main(int argc, char **argv)
 	if (options.term) {
 		free(options.term);
 		options.term = NULL;
+	}
+	if (options.password_file) {
+		free(options.password_file);
+		options.password_file = NULL;
 	}
 	if (res) {
 		free(res);

--- a/src/options.h
+++ b/src/options.h
@@ -55,6 +55,7 @@ struct opts {
 	char *term;
 	char *username;
 	char *password;
+	char *password_file;
 };
 
 /** Extern declarations **/

--- a/src/rc.c
+++ b/src/rc.c
@@ -41,7 +41,6 @@
 #include <fcntl.h>
 #include "gettext.h"
 #include "defs.h"
-#include "decrypt.h"
 #include "options.h"
 #include "mem.h"
 
@@ -212,12 +211,12 @@ read_rc(const char *file)
 			pfile = NULL;
 		}
 
-		if (decrypt(abs_file)) {
-			return(EXIT_FAILURE);
-		}
-
 		if (abs_file) {
-			free(abs_file);
+			/* Defer password file access so that errors don't
+			 * prevent processing of options like --version and
+			 * --help which should not be affected by
+			 * configuration errors. */
+			options.password_file = abs_file;
 			abs_file = NULL;
 		}
 #else


### PR DESCRIPTION
If the specified password file is missing (for example), the `--version`and `--help` options do not get processed. I think this is confusing as `--help` is something you might try to work out what you have done wrong. I would expect these operations not to depend on valid configurations. Indeed I would probably not expect the password decryption to be attempted at all if specifying those options. `--version` is the sort of operation a system administrator's scripts might call ex pecting passive behaviour only.

This patch defers the password file access until after the option and config parsing is completed, allowing options like help/version to be processed and the application to quit.

Why you might _not_ want this patch? This introduces marginal extra complexity, including an additional field in the options struct that is really only an intermediate value.