### PR TITLE
Fixing unveil.

### DIFF
--- a/src/mem.c
+++ b/src/mem.c
@@ -57,7 +57,7 @@ xmalloc(size_t n)
     memset(ptr, 0, n);
     return ptr;
   } else {
-    errx(EX_SOFTWARE,_("out of memory (unable to allocate %ld bytes)"), n);
+    errx(EX_SOFTWARE,_("out of memory (unable to allocate %zu bytes)"), n);
   }
   /* should never get here */
   return NULL;

--- a/src/rc.c
+++ b/src/rc.c
@@ -227,12 +227,13 @@ read_rc(const char *file)
 #endif
 	}
 
-#ifdef HAVE_UNVEIL
 	if (options.verify == 1) {
+#ifdef HAVE_UNVEIL
 		if (unveil("/etc/ssl", "r") == -1) {
 			warn(_("Unable to unveil %s"), "/etc/ssl/");
 			return(EXIT_FAILURE);
 		}
+#endif
 	}
 	if (options.netrc == 1) {
 		home = getenv("HOME");
@@ -246,16 +247,17 @@ read_rc(const char *file)
 			warnx(_("Unable to build password file string"));
 			return(EXIT_FAILURE);
 		}
+#ifdef HAVE_UNVEIL
 		if (unveil(abs_file, "r") == -1) {
 			warn(_("Unable to unveil %s"), abs_file);
 			return(EXIT_FAILURE);
 		}
+#endif
 		if (abs_file) {
 			free(abs_file);
 			abs_file = NULL;
 		}
 	}
-#endif
 
 	return(EXIT_SUCCESS);
 }


### PR DESCRIPTION
The ifdef's for unveil were in the wrong spots (too broad).
Also changed to use '%zu' for size_t.

This will address the first 2 issues in #18 . However I do not get the 3rd warning or error, note that (`strsep`)[https://github.com/t-brown/mcds/blob/3fec633d83fd84337c023c99f2faff8818fdc9a9/src/rc.c#L120C17-L120C23] replaces the delimiter with `\0`. 