### PR TITLE
Ability to run `-V` and `-h` before `decrypt()`.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -100,23 +100,12 @@ main(int argc, char **argv)
 	textdomain(PACKAGE);
 #endif
 
-	/* This is kind-of wonky. We try and read our default configuration
-	 * file, then parse the command line (so it overrides the defaults),
-	 * then finally if the command line specified a configuration file
-	 * read that.
-	 */
-	if (read_rc(file)) {
-		return(EXIT_FAILURE);
-	}
-
 	if (parse_argv(argc, argv, &file)) {
 		return(EXIT_FAILURE);
 	}
 
-	if (file != NULL) {
-		if (read_rc(file)) {
-			return(EXIT_FAILURE);
-		}
+	if (read_rc(file)) {
+		return(EXIT_FAILURE);
 	}
 
 #ifdef HAVE_UNVEIL


### PR DESCRIPTION
We used to read the default rc file then parse the command line, and then read a user supplied config file.

We changed this logic to parse the command line first so as to be able to use `-V` and `-h` and exit quickly. Then to read a configuration file. If one is not supplied as an argument, we just read the default one (~/.mcdsrc). The only option/argument that is specified in both the rc file and arguments is the URL, and I originally made a check to make sure to not overwrite it if it was an argument when reading the rc file.