### PR TITLE
Fail query on HTTP error

### DIFF
--- a/po/mcds.pot
+++ b/po/mcds.pot
@@ -32,7 +32,7 @@ msgid "Unable to search for %s: %s"
 msgstr ""
 
 #: src/carddav.c:140
-msgid "Unable to obtain a result."
+msgid "Unable to obtain a result: %d (%d bytes)."
 msgstr ""
 
 #: src/carddav.c:195


### PR DESCRIPTION
If there is an HTTP error conducting the query (e.g. `401 Unauthorized`) then this is not visible without verbose output. I think the utility should fail with a non-zero return code and error message so that the user does not think there were just no matching contacts or wonder if the operation (e.g. ^t in mutt) was not registered.