### PR TITLE
prompt, save and restore password with libsecret

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -59,13 +59,16 @@ AS_IF([test "$HAVE_PKG_LIBSECRET" != "0"],
                 [AC_DEFINE([HAVE_LIBSECRET], [1], [Define to 1 if you have libsecret support])
 		 AC_SUBST(LIBSECRET_CFLAGS)
 		 AC_SUBST(LIBSECRET_LIBS)
+		 AM_CONDITIONAL([WANT_LIBSECRET], [test x = x])
                  enable_libsecret=yes
                 ],
                 [AC_DEFINE([HAVE_LIBSECRET], [0], [Define to 1 if you have libsecret support])
+		 AM_CONDITIONAL([WANT_LIBSECRET], [test x = y])
                  enable_libsecret=no
 		]
           )],
           [AC_DEFINE([HAVE_LIBSECRET], [0], [Define to 1 if you have libsecret support])
+           AM_CONDITIONAL([WANT_LIBSECRET], [test x = y])
            enable_libsecret=no
           ]
 )

--- a/configure.ac
+++ b/configure.ac
@@ -49,6 +49,26 @@ AC_CONFIG_FILES([Makefile
 
 PKG_CHECK_MODULES([CURL], [libcurl])
 PKG_CHECK_MODULES([XML], [libxml-2.0])
+PKG_CHECK_MODULES([SECRET], [libsecret-1],, [HAVE_PKG_LIBSECRET=0])
+
+AC_ARG_ENABLE([libsecret],
+        AS_HELP_STRING([--disable-libsecret], [do not use libsecret support]))
+
+AS_IF([test "$HAVE_PKG_LIBSECRET" != "0"],
+         [AS_IF([test x$enable_libsecret != xno],
+                [AC_DEFINE([HAVE_LIBSECRET], [1], [Define to 1 if you have libsecret support])
+		 AC_SUBST(LIBSECRET_CFLAGS)
+		 AC_SUBST(LIBSECRET_LIBS)
+                 enable_libsecret=yes
+                ],
+                [AC_DEFINE([HAVE_LIBSECRET], [0], [Define to 1 if you have libsecret support])
+                 enable_libsecret=no
+		]
+          )],
+          [AC_DEFINE([HAVE_LIBSECRET], [0], [Define to 1 if you have libsecret support])
+           enable_libsecret=no
+          ]
+)
 
 dnl locate gpgme and gpg
 AH_TEMPLATE([GPGME_CONFIG], [Defined to the full path of gpgme-config])
@@ -102,4 +122,5 @@ echo "Installation prefix        : $prefix"
 echo "C command                  : $CC $CFLAGS"
 echo "Linker                     : $LD $LDFLAGS $LIBS"
 echo "Enable GPGME               : $enable_gpgme"
+echo "Enable libsecret           : $enable_libsecret"
 echo

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -23,11 +23,15 @@ mcds_SOURCES = defs.h                           \
                carddav.c        carddav.h       \
                xml.c            xml.h           \
                vcard.c          vcard.h         \
-	       secret.c         secret.h        \
-               rc.c             rc.h
+               rc.c             rc.h            \
+	       prompt.c         prompt.h
 
 if WANT_GPGME
 mcds_SOURCES += decrypt.c       decrypt.h
+endif
+
+if WANT_LIBSECRET
+mcds_SOURCES +=	secret.c         secret.h
 endif
 
 noinst_HEADERS = gettext.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -6,11 +6,13 @@ bin_PROGRAMS = mcds
 
 mcds_CPPFLAGS = $(CURL_CFLAGS)                  \
                 $(XML_CFLAGS)                   \
+                $(SECRET_CFLAGS)                \
                 $(GPGME_CFLAGS)
 
 mcds_LDADD = $(LTLIBINTL)                       \
              $(CURL_LIBS)                       \
              $(XML_LIBS)                        \
+             $(SECRET_LIBS)                     \
              $(GPGME_LIBS)
 
 mcds_SOURCES = defs.h                           \
@@ -21,6 +23,7 @@ mcds_SOURCES = defs.h                           \
                carddav.c        carddav.h       \
                xml.c            xml.h           \
                vcard.c          vcard.h         \
+	       secret.c         secret.h        \
                rc.c             rc.h
 
 if WANT_GPGME

--- a/src/main.c
+++ b/src/main.c
@@ -53,6 +53,9 @@
 #include "carddav.h"
 #include "xml.h"
 
+#if HAVE_LIBSECRET
+#include "secret.h"
+#endif
 
 /* Initalise extern definitions */
 #define X(a, b) b,
@@ -121,6 +124,7 @@ main(int argc, char **argv)
 		fprintf(stderr, "  SSL Verify        : %d\n", options.verify);
 		fprintf(stderr, "  Use .netrc        : %d\n", options.netrc);
 		fprintf(stderr, "  Use libsecret     : %d\n", options.libsecret);
+		fprintf(stderr, "  Save password     : %d\n", options.save);
 		fprintf(stderr, "  Password prompted : %d\n", options.pwprompt);
 		fprintf(stderr, "  Username          : %s\n", options.username);
 		fprintf(stderr, "  Password          : %s\n", options.password);
@@ -143,6 +147,16 @@ main(int argc, char **argv)
 
 	if (parse_xml(res)) {
 		return(EXIT_FAILURE);
+	}
+
+	if (options.save) {
+#if HAVE_LIBSECRET
+		if (options.libsecret) {
+			if(store_password()) {
+				return(EXIT_FAILURE);
+			}
+		}
+#endif
 	}
 
 	if (options.url) {
@@ -188,12 +202,13 @@ parse_argv(int argc, char **argv, char **file)
 {
 	int opt = 0;
 	int opt_index = 0;
-	char *soptions = "c:hpq:s:u:Vv";        /* short options structure */
+	char *soptions = "c:hpq:Ss:u:Vv";        /* short options structure */
 	static struct option loptions[] = {     /* long options structure */
 		{"config",     required_argument,  NULL,  'c'},
 		{"help",       no_argument,        NULL,  'h'},
 		{"password",   no_argument,        NULL,  'p'},
 		{"query",      required_argument,  NULL,  'q'},
+		{"save",       no_argument,        NULL,  'S'},
 		{"search",     required_argument,  NULL,  's'},
 		{"url",        required_argument,  NULL,  'u'},
 		{"version",    no_argument,        NULL,  'V'},
@@ -232,6 +247,9 @@ parse_argv(int argc, char **argv, char **file)
 				   optarg[0] == 'T' ) {
 				options.query = telephone;
 			}
+			break;
+		case 'S':
+			options.save = 1;
 			break;
 		case 's':
 			if (optarg[0] == 'a' ||
@@ -297,6 +315,7 @@ usage: %s [-c config] [-h] [-q a|e|n|t] [-s a|e|n|t] [-u URL] [-V] [-v] string\n
                      e = email\n\
                      n = name\n\
                      t = telephone\n\
+  -S, --save         Save the password.\n\
   -s, --search a|n|e|t Search term (default email). Known terms are:\n\
                      a = address\n\
                      e = email\n\
@@ -324,7 +343,7 @@ License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>\n\
 This is free software: you are free to change and redistribute it.\n\
 There is NO WARRANTY, to the extent permitted by law.\n\n"), "2019");
 	printf(_("Compiled on %s at %s:\n"
-		 " -  %s GPGME support.\n"
+		 " - %s GPGME support.\n"
 		 " - %s libsecret support.\n\n"),
 	       __DATE__, __TIME__,
 	       ngettext("with", "with-out", HAVE_GPGME),

--- a/src/main.c
+++ b/src/main.c
@@ -52,7 +52,6 @@
 #include "curl.h"
 #include "carddav.h"
 #include "xml.h"
-#include "secret.h"
 
 
 /* Initalise extern definitions */
@@ -118,16 +117,17 @@ main(int argc, char **argv)
 
 	if (options.verbose) {
 		fprintf(stderr, "%s options are:\n", program_name());
-		fprintf(stderr, "  URL        : %s\n", options.url);
-		fprintf(stderr, "  SSL Verify : %d\n", options.verify);
-		fprintf(stderr, "  Use .netrc : %d\n", options.netrc);
-		fprintf(stderr, "  PW prompted: %d\n", options.pwprompt);
-		fprintf(stderr, "  Username   : %s\n", options.username);
-		fprintf(stderr, "  Password   : %s\n", options.password);
-		fprintf(stderr, "  Query term : %s\n", options.term);
-		fprintf(stderr, "  Query      : %s\n",
+		fprintf(stderr, "  URL               : %s\n", options.url);
+		fprintf(stderr, "  SSL Verify        : %d\n", options.verify);
+		fprintf(stderr, "  Use .netrc        : %d\n", options.netrc);
+		fprintf(stderr, "  Use libsecret     : %d\n", options.libsecret);
+		fprintf(stderr, "  Password prompted : %d\n", options.pwprompt);
+		fprintf(stderr, "  Username          : %s\n", options.username);
+		fprintf(stderr, "  Password          : %s\n", options.password);
+		fprintf(stderr, "  Query term        : %s\n", options.term);
+		fprintf(stderr, "  Query             : %s\n",
 				sterm_name[options.query]);
-		fprintf(stderr, "  Search     : %s\n",
+		fprintf(stderr, "  Search            : %s\n",
 				sterm_name[options.search]);
 	}
 
@@ -136,12 +136,7 @@ main(int argc, char **argv)
 	}
 	if (query(hdl, &res)) {
 		return(EXIT_FAILURE);
-}
-#if HAVE_LIBSECRET
-	if (options.pwprompt && options.password) {
-		store_password();
 	}
-#endif
 	if (cfini(&hdl)) {
 		return(EXIT_FAILURE);
 	}
@@ -197,12 +192,12 @@ parse_argv(int argc, char **argv, char **file)
 	static struct option loptions[] = {     /* long options structure */
 		{"config",     required_argument,  NULL,  'c'},
 		{"help",       no_argument,        NULL,  'h'},
+		{"password",   no_argument,        NULL,  'p'},
 		{"query",      required_argument,  NULL,  'q'},
 		{"search",     required_argument,  NULL,  's'},
 		{"url",        required_argument,  NULL,  'u'},
 		{"version",    no_argument,        NULL,  'V'},
 		{"verbose",    no_argument,        NULL,  'v'},
-		{"password",   no_argument,        NULL,  'p'},
 		{NULL,         1,                  NULL,  0}
 	};
 
@@ -296,7 +291,7 @@ print_usage(void)
 usage: %s [-c config] [-h] [-q a|e|n|t] [-s a|e|n|t] [-u URL] [-V] [-v] string\n\
   -c, --config       A configuration file to use.\n\
   -h, --help         Display this help and exit.\n\
-  -p, --password     Force a password prompt.\n\
+  -p, --password     Prompt for a password.\n\
   -q, --query  a|e|n|t Query term (default name). Known terms are:\n\
                      a = address\n\
                      e = email\n\
@@ -329,8 +324,8 @@ License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>\n\
 This is free software: you are free to change and redistribute it.\n\
 There is NO WARRANTY, to the extent permitted by law.\n\n"), "2019");
 	printf(_("Compiled on %s at %s:\n"
-		 "  %s GPGME support and\n"
-		 "  %s libsecret support.\n\n"),
+		 " -  %s GPGME support.\n"
+		 " - %s libsecret support.\n\n"),
 	       __DATE__, __TIME__,
 	       ngettext("with", "with-out", HAVE_GPGME),
 	       ngettext("with", "with-out", HAVE_LIBSECRET)

--- a/src/main.c
+++ b/src/main.c
@@ -52,6 +52,7 @@
 #include "curl.h"
 #include "carddav.h"
 #include "xml.h"
+#include "secret.h"
 
 
 /* Initalise extern definitions */
@@ -120,6 +121,7 @@ main(int argc, char **argv)
 		fprintf(stderr, "  URL        : %s\n", options.url);
 		fprintf(stderr, "  SSL Verify : %d\n", options.verify);
 		fprintf(stderr, "  Use .netrc : %d\n", options.netrc);
+		fprintf(stderr, "  PW prompted: %d\n", options.pwprompt);
 		fprintf(stderr, "  Username   : %s\n", options.username);
 		fprintf(stderr, "  Password   : %s\n", options.password);
 		fprintf(stderr, "  Query term : %s\n", options.term);
@@ -134,7 +136,12 @@ main(int argc, char **argv)
 	}
 	if (query(hdl, &res)) {
 		return(EXIT_FAILURE);
+}
+#if HAVE_LIBSECRET
+	if (options.pwprompt && options.password) {
+		store_password();
 	}
+#endif
 	if (cfini(&hdl)) {
 		return(EXIT_FAILURE);
 	}
@@ -150,6 +157,14 @@ main(int argc, char **argv)
 	if (options.term) {
 		free(options.term);
 		options.term = NULL;
+	}
+	if (options.username) {
+		free(options.username);
+		options.username = NULL;
+	}
+	if (options.password) {
+		free(options.password);
+		options.password = NULL;
 	}
 	if (res) {
 		free(res);
@@ -178,7 +193,7 @@ parse_argv(int argc, char **argv, char **file)
 {
 	int opt = 0;
 	int opt_index = 0;
-	char *soptions = "c:hq:s:u:Vv";         /* short options structure */
+	char *soptions = "c:hpq:s:u:Vv";        /* short options structure */
 	static struct option loptions[] = {     /* long options structure */
 		{"config",     required_argument,  NULL,  'c'},
 		{"help",       no_argument,        NULL,  'h'},
@@ -187,6 +202,7 @@ parse_argv(int argc, char **argv, char **file)
 		{"url",        required_argument,  NULL,  'u'},
 		{"version",    no_argument,        NULL,  'V'},
 		{"verbose",    no_argument,        NULL,  'v'},
+		{"password",   no_argument,        NULL,  'p'},
 		{NULL,         1,                  NULL,  0}
 	};
 
@@ -203,6 +219,9 @@ parse_argv(int argc, char **argv, char **file)
 			break;
 		case 'h':
 			print_usage();
+			break;
+		case 'p':
+			options.pwprompt = 1;
 			break;
 		case 'q':
 			if (optarg[0] == 'a' ||
@@ -277,6 +296,7 @@ print_usage(void)
 usage: %s [-c config] [-h] [-q a|e|n|t] [-s a|e|n|t] [-u URL] [-V] [-v] string\n\
   -c, --config       A configuration file to use.\n\
   -h, --help         Display this help and exit.\n\
+  -p, --password     Force a password prompt.\n\
   -q, --query  a|e|n|t Query term (default name). Known terms are:\n\
                      a = address\n\
                      e = email\n\
@@ -308,8 +328,12 @@ Copyright (C) %s Timothy Brown.\n\
 License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>\n\
 This is free software: you are free to change and redistribute it.\n\
 There is NO WARRANTY, to the extent permitted by law.\n\n"), "2019");
-	printf(_("Compiled on %s at %s %s GPGME support.\n\n"),
-	       __DATE__, __TIME__, ngettext("with", "with-out", HAVE_GPGME)
+	printf(_("Compiled on %s at %s:\n"
+		 "  %s GPGME support and\n"
+		 "  %s libsecret support.\n\n"),
+	       __DATE__, __TIME__,
+	       ngettext("with", "with-out", HAVE_GPGME),
+	       ngettext("with", "with-out", HAVE_LIBSECRET)
 	       );
 	exit(EXIT_FAILURE);
 }

--- a/src/mcds.1
+++ b/src/mcds.1
@@ -20,7 +20,7 @@
 .\"
 .\" $Id$
 .\"
-.Dd March 4, 2014
+.Dd November 5, 2024
 .Dt MCDS 1
 .Os
 .Sh NAME
@@ -29,8 +29,9 @@
 .Sh SYNOPSIS
 .Nm
 .Op Fl c Ar config_file
-.Op Fl hVv
+.Op Fl hVvp
 .Op Fl q Cm a | e | n | t
+.Op Fl S
 .Op Fl s Cm a | e | n | t
 .Op Fl u Ar URL
 .Ar term
@@ -64,6 +65,8 @@ Query for the full-name field.
 .It Cm t
 Query for the telephone field.
 .El
+.It Fl S
+Save the password.
 .It Fl s Cm a | e | n | t
 The search term to return.
 Known terms are:
@@ -122,6 +125,10 @@ will not use the
 file.
 .It Cm password_file No \&= Ar password.gpg
 The GPG encrypted file containing the password for the CardDAV server.
+.It Cm libsecret No \&= Op Cm yes | no
+Use 
+.Lb libsecret
+to store and retrieve the password.
 .El
 .It Pa ~/.netrc
 Used to access your username and password when authenticating with the

--- a/src/mcds.1
+++ b/src/mcds.1
@@ -48,6 +48,8 @@ Specifies an alternative configuration file. The default file is
 .Pa ~/.mcdsrc .
 .It Fl h
 Print help text to standard output and exit.
+.It Fl p
+Force the presentation of a password prompt.
 .It Fl q Cm a | e | n | t
 The term to query against.
 Known terms are:
@@ -159,6 +161,14 @@ netrc = yes
 Now the query command can be shortened to:
 .Bd -literal -offset indent
 set query_command="mcds '%s'"
+.Ed
+.Pp
+When compiled against libsecret,
+.Nm
+saves passwords provided at the password prompt. To replace the saved
+password (or to clear, entering no password at the prompt):
+.Bd -literal -offset indent
+mcds -p
 .Ed
 .Sh SEE ALSO
 .Xr curl 1 ,

--- a/src/options.h
+++ b/src/options.h
@@ -51,6 +51,7 @@ struct opts {
 	int netrc;
 	int pwprompt;
 	int libsecret;
+	int save;
 	enum s_terms query;
 	enum s_terms search;
 	char *url;

--- a/src/prompt.c
+++ b/src/prompt.c
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2024  Andrew Bower
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * \file prompt.c
+ * Routine to prompt for a password.
+ *
+ * \ingroup prompt
+ * \{
+ **/
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <err.h>
+#include <errno.h>
+#include <locale.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <termios.h>
+#include "gettext.h"
+#include "defs.h"
+#include "options.h"
+#include "mem.h"
+#include "prompt.h"
+
+
+int
+prompt_password(void)
+{
+	struct termios tios_save;
+	struct termios tios;
+	FILE *console;
+	char *password = NULL;
+	int console_fd;
+	ssize_t len;
+	ssize_t sz;
+
+	/* Open controlling terminal */
+	console = fopen("/dev/tty", "w+");
+	if (console == NULL) {
+		warn(_("Could not open console for password prompt"));
+		return(EXIT_FAILURE);
+	}
+	console_fd = fileno(console);
+
+	/* Output prompt */
+	fprintf(console, _("mcds: password for %s at %s: "),
+		options.username, options.url);
+	fflush(console);
+
+	/* Do not echo password */
+	if (tcgetattr(console_fd, &tios_save) != 0) {
+		warn(_("Could not turn off echo for password prompt"));
+		fclose(console);
+		return(EXIT_FAILURE);
+	}
+	tios = tios_save;
+	tios.c_lflag &= ~ECHO;
+	if (tcsetattr(console_fd, TCSAFLUSH, &tios) != 0) {
+	  warn(_("Could not turn off echo for password prompt"));
+		fclose(console);
+		return(EXIT_FAILURE);
+	}
+
+	/* Read password */
+	len = getline(&password, &sz, console);
+	fprintf(console, "\n");
+	fflush(console);
+	if (len < 1) {
+		free(password); /* Yes, getline(3) says to do this! */
+		warn(_("Could not read password"));
+	} else {
+		/* Remove line ending */
+		password[len - 1] = '\0';
+		options.password = password;
+	}
+
+	/* Restore echo state */
+	tcsetattr(console_fd, TCSAFLUSH, &tios_save);
+	fclose(console);
+
+	return(EXIT_SUCCESS);
+}
+
+/**
+ * \}
+ **/

--- a/src/prompt.c
+++ b/src/prompt.c
@@ -55,7 +55,7 @@ prompt_password(void)
 	char *password = NULL;
 	int console_fd;
 	ssize_t len;
-	ssize_t sz;
+	size_t sz;
 
 	/* Open controlling terminal */
 	console = fopen("/dev/tty", "w+");

--- a/src/prompt.h
+++ b/src/prompt.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Timothy Brown
+ * Copyright (C) 2024 Andrew Bower
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -17,57 +17,29 @@
  */
 
 /**
- * \file options.h
- * Internal definitions for program options.
+ * \file prompt.h
+ * Internal definitions for password prompting.
  *
- * \ingroup options
+ * \ingroup secret
  * \{
  **/
 
-#ifndef MCDS_OPTIONS_H
-#define MCDS_OPTIONS_H
+#ifndef MCDS_PROMPT_H
+#define MCDS_PROMPT_H
 
 #ifdef __cplusplus
 extern "C"
 {
 #endif
 
-#define STERMS_TABLE            \
-	X(name,        "FN")    \
-	X(email,       "EMAIL") \
-	X(address,     "ADR")   \
-	X(telephone,   "TEL")
-
-#define X(a, b) a,
-enum s_terms {
-	STERMS_TABLE
-};
-#undef X
-
-/** Program command line options **/
-struct opts {
-	int verbose;
-	int verify;
-	int netrc;
-	int pwprompt;
-	int libsecret;
-	enum s_terms query;
-	enum s_terms search;
-	char *url;
-	char *term;
-	char *username;
-	char *password;
-};
-
-/** Extern declarations **/
-extern struct opts options;
-extern char *sterm_name[];
+/** Prompt for user's password */
+int prompt_password(void);
 
 #ifdef __cplusplus
 }                               /* extern "C" */
 #endif
 
-#endif                          /* MCDS_OPTIONS_H */
+#endif                          /* MCDS_PROMPT_H */
 /**
  * \}
  **/

--- a/src/rc.c
+++ b/src/rc.c
@@ -187,7 +187,7 @@ read_rc(const char *file)
 	}
 
 	if (options.username == NULL) {
-		options.username = getenv("USER");
+		options.username = strdup(getenv("USER"));
 	}
 
 	if (options.pwprompt) {

--- a/src/secret.c
+++ b/src/secret.c
@@ -1,0 +1,183 @@
+
+/*
+ * Copyright (C) 2024  Andrew Bower
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * \file secret.c
+ * Routines to manage access to credential store.
+ *
+ * \ingroup secret
+ * \{
+ **/
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <err.h>
+#include <errno.h>
+#include <locale.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <termios.h>
+#include "gettext.h"
+#include "defs.h"
+#include "options.h"
+#include "mem.h"
+#include "secret.h"
+
+#if HAVE_LIBSECRET
+#include <libsecret/secret.h>
+
+#define MCDS_NAMESPACE "com.github.t-brown.mcds"
+#define MCDS_SECRET_SCHEMA_NAME MCDS_NAMESPACE ".password"
+#define MCDS_SECRET_KEY_URL "url"
+#define MCDS_SECRET_KEY_USER "user"
+
+static const SecretSchema mcds_secret_schema = {
+	MCDS_SECRET_SCHEMA_NAME, SECRET_SCHEMA_NONE,
+	{
+		{ MCDS_SECRET_KEY_URL,  SECRET_SCHEMA_ATTRIBUTE_STRING },
+		{ MCDS_SECRET_KEY_USER, SECRET_SCHEMA_ATTRIBUTE_STRING },
+		{ "NULL", 0 }
+	}
+};
+
+void
+store_password(void)
+{
+	GError *error = NULL;
+
+	secret_password_store_sync(&mcds_secret_schema,
+				   SECRET_COLLECTION_DEFAULT,
+				   "Mutt CardDAV Search user credentials",
+				   options.password,
+				   NULL, &error,
+				   MCDS_SECRET_KEY_URL, options.url,
+				   MCDS_SECRET_KEY_USER, options.username,
+				   NULL);
+	if (error) {
+		/* This is a non-fatal condition. */
+		warnx(_("error storing password with libsecret: %s"), error->message);
+		g_error_free(error);
+	}
+}
+
+void
+lookup_password(void)
+{
+	GError *error = NULL;
+
+	gchar *password = secret_password_lookup_sync(&mcds_secret_schema,
+						      NULL, &error,
+						      MCDS_SECRET_KEY_URL, options.url,
+						      MCDS_SECRET_KEY_USER, options.username,
+						      NULL);
+	if (error) {
+		/* This is a non-fatal condition. */
+		warnx(_("error retrieving password with libsecret: %s"), error->message);
+		g_error_free(error);
+	}
+
+	if (password)
+		options.password = strdup(password);
+	secret_password_free(password);
+}
+
+void
+clear_password(void)
+{
+	GError *error = NULL;
+
+	gboolean removed = secret_password_clear_sync(&mcds_secret_schema,
+						      NULL, &error,
+						      MCDS_SECRET_KEY_URL, options.url,
+						      MCDS_SECRET_KEY_USER, options.username,
+						      NULL);
+	if (error) {
+		/* This is a non-fatal condition. */
+		warnx(_("error clearing password with libsecret: %s"), error->message);
+		g_error_free(error);
+	}
+}
+#endif
+
+void
+prompt_password(void)
+{
+	struct termios tios_save;
+	struct termios tios;
+	FILE *console;
+	char *password = NULL;
+	int console_fd;
+	ssize_t len;
+	ssize_t sz;
+
+	/* Open controlling terminal */
+	console = fopen("/dev/tty", "w+");
+	if (console == NULL) {
+		warn(_("Could not open console for password prompt"));
+		return;
+	}
+	console_fd = fileno(console);
+
+	/* Output prompt */
+	fprintf(console, _("mcds: password for %s at %s: "),
+		options.username, options.url);
+	fflush(console);
+
+	/* Do not echo password */
+	if (tcgetattr(console_fd, &tios_save) != 0) {
+	  warn(_("Could not turn off echo for password prompt"));
+		goto finish;
+	}
+      	tios = tios_save;
+	tios.c_lflag &= ~ECHO;
+  	if (tcsetattr(console_fd, TCSAFLUSH, &tios) != 0) {
+	  warn(_("Could not turn off echo for password prompt"));
+		goto finish;
+	}
+
+	/* Read password */
+	len = getline(&password, &sz, console);
+	fprintf(console, "\n");
+	fflush(console);
+	if (len < 1) {
+		free(password); /* Yes, getline(3) says to do this! */
+		warn(_("Could not read password"));
+	} else {
+		/* Remove line ending */
+		password[len - 1] = '\0';
+		options.password = password;
+	}
+
+	/* Restore echo state */
+	tcsetattr(console_fd, TCSAFLUSH, &tios_save);
+
+finish:
+	fclose(console);
+}
+
+/**
+ * \}
+ **/

--- a/src/secret.c
+++ b/src/secret.c
@@ -77,9 +77,9 @@ store_password(void)
 				   MCDS_SECRET_KEY_USER, options.username,
 				   NULL);
 	if (error) {
-		/* This is a non-fatal condition. */
 		warnx(_("error storing password with libsecret: %s"), error->message);
 		g_error_free(error);
+		return(EXIT_FAILURE);
 	}
 	return(EXIT_SUCCESS);
 }

--- a/src/secret.h
+++ b/src/secret.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Timothy Brown
+ * Copyright (C) 2024 Andrew Bower
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -17,56 +17,44 @@
  */
 
 /**
- * \file options.h
- * Internal definitions for program options.
+ * \file secret.h
+ * Internal definitions for accessing credential store.
  *
- * \ingroup options
+ * \ingroup secret
  * \{
  **/
 
-#ifndef MCDS_OPTIONS_H
-#define MCDS_OPTIONS_H
+#ifndef MCDS_SECRET_H
+#define MCDS_SECRET_H
+
+#if HAVE_LIBSECRET
+#include <libsecret/secret.h>
+#endif
 
 #ifdef __cplusplus
 extern "C"
 {
 #endif
 
-#define STERMS_TABLE            \
-	X(name,        "FN")    \
-	X(email,       "EMAIL") \
-	X(address,     "ADR")   \
-	X(telephone,   "TEL")
+#if HAVE_LIBSECRET
+/** Save password in user's credential store */
+void store_password(void);
 
-#define X(a, b) a,
-enum s_terms {
-	STERMS_TABLE
-};
-#undef X
+/** Lookup password in user's credential store */
+void lookup_password(void);
 
-/** Program command line options **/
-struct opts {
-	int verbose;
-	int verify;
-	int netrc;
-	int pwprompt;
-	enum s_terms query;
-	enum s_terms search;
-	char *url;
-	char *term;
-	char *username;
-	char *password;
-};
+/** Clear password in user's credential store */
+void clear_password(void);
+#endif
 
-/** Extern declarations **/
-extern struct opts options;
-extern char *sterm_name[];
+/** Prompt for user's password */
+void prompt_password(void);
 
 #ifdef __cplusplus
 }                               /* extern "C" */
 #endif
 
-#endif                          /* MCDS_OPTIONS_H */
+#endif                          /* MCDS_SECRET_H */
 /**
  * \}
  **/

--- a/src/secret.h
+++ b/src/secret.h
@@ -36,19 +36,14 @@ extern "C"
 {
 #endif
 
-#if HAVE_LIBSECRET
 /** Save password in user's credential store */
-void store_password(void);
+int store_password(void);
 
 /** Lookup password in user's credential store */
-void lookup_password(void);
+int lookup_password(void);
 
 /** Clear password in user's credential store */
-void clear_password(void);
-#endif
-
-/** Prompt for user's password */
-void prompt_password(void);
+int clear_password(void);
 
 #ifdef __cplusplus
 }                               /* extern "C" */


### PR DESCRIPTION
This attempt to close #20 was surprisingly straightforward. Some caveats come to mind:

1. I am new to autoconf so the `configure.ac` changes are a bit cargo-culty - may need some attention!
2. The ordering for trying credentials needs review: store -> gpg -> netrc -> prompt.
3. Do you want the password prompt at all when the store is not available?
4. Should it be possible to disable the store at runtime?
5. The `options.pwprompt` setting gets overwritten with whether the prompt was actually used so that _main_ knows whether to request the password be saved upon a successful query (we don't save the decrypted or netrc passsword!). That's a change of semantics versus the other 'options'.

This is what the store looks like:
```
$ lssecret
Item:	Mutt CardDAV Search user credentials
Key:	url
Value:	https://my.cloud.server/remote.php/dav/addressbooks/users/fred/contacts
Key:	user
Value:	fred
Key:	xdg:schema
Value:	com.github.t-brown.mcds.password
```

How to make a first query
```
$ src/mcds -u http://foobar/ bloggs
mcds: password for fred at http://foobar/:
```

The password then gets stored if successful and the prompt not presented again unless run with `-p`.

Tested with `libsecret-1-dev` not present and with `./configure --disable-libsecret`.

```
$ src/mcds -V
mcds (GNU mcds) 1.7
Copyright (C) 2019 Timothy Brown.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Compiled on Oct 21 2024 at 22:17:16:
  with GPGME support and
  with libsecret support.
```