### PR TITLE
clear_password(): appease -Werror=unused-variable

### DIFF
--- a/src/secret.c
+++ b/src/secret.c
@@ -122,7 +122,7 @@ clear_password(void)
 		warnx(_("error clearing password with libsecret: %s"), error->message);
 		g_error_free(error);
 	}
-	return(EXIT_SUCCESS);
+	return(!error && removed ? EXIT_SUCCESS : EXIT_FAILURE);
 }
 #endif
 


### PR DESCRIPTION
```
secret.c: In function ‘clear_password’:
secret.c:115:18: error: unused variable ‘removed’ [-Werror=unused-variable]
  115 |         gboolean removed = secret_password_clear_sync(&mcds_secret_schema,
      |                  ^~~~~~~
cc1: all warnings being treated as errors
```