### PR TITLE
only store password when requested

### DIFF
--- a/src/rc.c
+++ b/src/rc.c
@@ -200,8 +200,6 @@ read_rc(const char *file)
 			if (lookup_password() == 1) {
 				return(EXIT_FAILURE);
 			}
-		} else {
-			store_password();
 		}
 	}
 #endif


### PR DESCRIPTION
Without this patch the password gets saved regardless, which is contra to the intent of the -S option whereby this is only done explicitly.