### PR TITLE
Unfold vCard before parsing

### DIFF
--- a/src/vcard.c
+++ b/src/vcard.c
@@ -41,6 +41,37 @@
 #include "vcard.h"
 
 /**
+ * Compile regex, checking and handling errors.
+ *
+ * \parm[in] preg The compiled regex.
+ * \parm[in] regex The pattern to match.
+ * \parm[in] cflags The compilation flags according to regex(3).
+ *
+ * \retval 0 If there were no errors.
+ * \retval 1 If an error was encounted.
+ **/
+static int
+xregcomp(regex_t *preg, const char *regex, int cflags) {
+	int rerr = 0;			/* Regex error code */
+	size_t rlen = 0;		/* Regex error string length */
+	char *rstr = NULL;		/* Regex error string */
+
+	rerr = regcomp(preg, regex, REG_EXTENDED | cflags);
+	if (rerr != 0) {
+		rlen = regerror(rerr, preg, NULL, 0);
+		rstr = xmalloc((rlen+1)*sizeof(char));
+		regerror(rerr, preg, rstr, rlen);
+		warnx(_("Unable to compile regex '%s': %s\n"), regex, rstr);
+		if (rstr) {
+			free(rstr);
+			rstr = NULL;
+		}
+		return 1;
+	}
+	return 0;
+}
+
+/**
  * Search a query's result. This will run regexs over the result
  * to filter the data.
  * The first regex will be to obtain the name (FN property).
@@ -63,8 +94,6 @@ search(const char *card)
 	int plen = 0;			/* Length of snprintf()'s */
 
 	int rerr = 0;			/* Regex error code */
-	size_t rlen = 0;		/* Regex error string length */
-	char *rstr = NULL;		/* Regex error string */
 
 	size_t qlen = 0;		/* Length of the query string */
 	char *q = NULL;			/* Regex pattern for query */
@@ -96,15 +125,7 @@ search(const char *card)
 		return(EXIT_FAILURE);
 	}
 
-	if ((rerr = regcomp(&rq, q, REG_EXTENDED|REG_NEWLINE|REG_ICASE)) != 0) {
-		rlen = regerror(rerr, &rq, NULL, 0);
-		rstr = xmalloc((rlen+1)*sizeof(char));
-		regerror(rerr, &rq, rstr, rlen);
-		warnx(_("Unable to compile regex '%s': %s\n"), q, rstr);
-		if (rstr) {
-			free(rstr);
-			rstr = NULL;
-		}
+	if (xregcomp(&rq, q, REG_NEWLINE|REG_ICASE) != 0) {
 		return(EXIT_FAILURE);
 	}
 
@@ -119,15 +140,7 @@ search(const char *card)
 		return(EXIT_FAILURE);
 	}
 
-	if ((rerr = regcomp(&rs, s, REG_EXTENDED|REG_NEWLINE)) != 0) {
-		rlen = regerror(rerr, &rs, NULL, 0);
-		rstr = xmalloc((rlen+1)*sizeof(char));
-		regerror(rerr, &rs, rstr, rlen);
-		warnx(_("Unable to compile regex '%s': %s\n"), s, rstr);
-		if (rstr) {
-			free(rstr);
-			rstr = NULL;
-		}
+	if (xregcomp(&rs, s, REG_NEWLINE) != 0) {
 		return(EXIT_FAILURE);
 	}
 

--- a/src/vcard.c
+++ b/src/vcard.c
@@ -88,28 +88,51 @@ unfold(char *vcard)
 	regmatch_t matches[1];
 	regex_t re;
 	size_t length = strlen(vcard);
-	size_t in_ptr = 0; /* AKA cut_to */
-	size_t out_ptr = 0; /* AKA cut_from */
+
+	/* We have two cursors. The read pointer is never behind the
+	 * the write pointer because we only remove characters. */
+	size_t in_ptr = 0;
+	size_t out_ptr = 0;
 
 	if (xregcomp(&re, r, 0) != 0) {
 		return 1;
 	}
 
 	/* Hunt for folds and move the chunks inbetween them back by
-	 * the accumulated number of folding characters. */
+	 * the accumulated number of folding characters.
+	 *   Counter intuitively, we always move the section that is
+	 * BEFORE the whitespace we just found, because then we know
+	 * how much to move and don't blindly move all the rest of the
+	 * buffer for each iteration. */
 	while (regexec(&re, vcard + in_ptr, 1, matches, 0) == 0) {
+		/* We have matched some whitespace representing a 'fold'.
+		 * Sanity-check the matches record */
 		if (matches[0].rm_so == -1 || matches[0].rm_eo == -1) {
 			errx(EXIT_FAILURE, _("inconsistent regex result"));
 		}
+
+		/* We have matched a fold (whitespace to be removed).
+		 * move the text _between the last and current_ gaps to
+		 * to the current write pointer.
+		 *   If this is the _first_ fold, then this memmove
+		 * should be a NOP. If it is the _last_ fold, then the
+		 * final segment will be moved after the loop.
+		 *   rm_so has the length of text to move because it is the
+		 * offset of the whitespace which ends it. */
 		memmove(vcard + out_ptr,
 			vcard + in_ptr,
 			matches[0].rm_so);
+
+		/* Move the read pointer beyond the white space we found. */
 		in_ptr   = in_ptr + matches[0].rm_eo;
+
+		/* Move the write pointer to beyond the text we just moved. */
 		out_ptr  = out_ptr + matches[0].rm_so;
 	}
 	if (options.verbose) {
 		fprintf(stderr, "Unfolding cut %zd bytes\n", in_ptr - out_ptr);
 	}
+	/* Move the final segment. Will be a NOP if we have had no folds. */
 	memmove(vcard + out_ptr, vcard + in_ptr, length - in_ptr + 1);
 
 	regfree(&re);

--- a/src/vcard.c
+++ b/src/vcard.c
@@ -43,7 +43,7 @@
 /**
  * Compile regex, checking and handling errors.
  *
- * \parm[in] preg The compiled regex.
+ * \parm[out] preg The compiled regex.
  * \parm[in] regex The pattern to match.
  * \parm[in] cflags The compilation flags according to regex(3).
  *
@@ -72,6 +72,51 @@ xregcomp(regex_t *preg, const char *regex, int cflags) {
 }
 
 /**
+ * Unfold a vCard per RFC6350 section 3.2.
+ *
+ * It will remove the gaps between folded lines in-place.
+ *
+ * \parm[in,out] card The vcard.
+ *
+ * \retval 0 If there were no errors.
+ * \retval 1 If an error was encounted.
+ **/
+static int
+unfold(char *vcard)
+{
+	static const char r[] = "\r?\n[ \t]";     /* Continuation fold */
+	regmatch_t matches[1];
+	regex_t re;
+	size_t length = strlen(vcard);
+	size_t in_ptr = 0; /* AKA cut_to */
+	size_t out_ptr = 0; /* AKA cut_from */
+
+	if (xregcomp(&re, r, 0) != 0) {
+		return 1;
+	}
+
+	/* Hunt for folds and move the chunks inbetween them back by
+	 * the accumulated number of folding characters. */
+	while (regexec(&re, vcard + in_ptr, 1, matches, 0) == 0) {
+		if (matches[0].rm_so == -1 || matches[0].rm_eo == -1) {
+			errx(EXIT_FAILURE, _("inconsistent regex result"));
+		}
+		memmove(vcard + out_ptr,
+			vcard + in_ptr,
+			matches[0].rm_so);
+		in_ptr   = in_ptr + matches[0].rm_eo;
+		out_ptr  = out_ptr + matches[0].rm_so;
+	}
+	if (options.verbose) {
+		fprintf(stderr, "Unfolding cut %zd bytes\n", in_ptr - out_ptr);
+	}
+	memmove(vcard + out_ptr, vcard + in_ptr, length - in_ptr + 1);
+
+	regfree(&re);
+	return 0;
+}
+
+/**
  * Search a query's result. This will run regexs over the result
  * to filter the data.
  * The first regex will be to obtain the name (FN property).
@@ -85,7 +130,7 @@ xregcomp(regex_t *preg, const char *regex, int cflags) {
  * \retval 1 If an error was encounted.
  **/
 int
-search(const char *card)
+search(char *card)
 {
 	/* Regex patterns */
 	static const char r[] = "%s(.*):(.*)";     /* Whole result */
@@ -106,6 +151,11 @@ search(const char *card)
 	regex_t rs = {0};		/* Regex precompiled search */
 
 	regmatch_t match[3] = {0};	/* Regex matches */
+
+	if (unfold(card)) {
+		warnx(_("Error unfolding vCard."));
+		return(EXIT_FAILURE);
+	}
 
 	/* Generate a quoted query term */
 	if (quote(options.term, &qt)) {

--- a/src/vcard.h
+++ b/src/vcard.h
@@ -32,8 +32,9 @@ extern "C"
 {
 #endif
 
-/** Search the vcard */
-int search(const char *);
+/** Search the vcard.
+ * The supplied card string will be unfolded in place so must be modifiable. */
+int search(char *);
 
 /** Quote a string for regex's */
 int quote(const char *, char **);

--- a/src/xml.c
+++ b/src/xml.c
@@ -107,7 +107,7 @@ walk_tree(xmlDocPtr doc, xmlNode *node)
 							_("Data:\n%s\n"),
 							data);
 					}
-					search((const char *)data);
+					search((char *)data);
 					xmlFree(data);
 				}
 		}


### PR DESCRIPTION
Closes #38 by unfolding vCard as per RFC before parsing it. This makes `mcds` usable for convenient command line queries of postal addresses which would otherwise be truncated.

This pipelined approach seems to be a simpler solution than building continuation handing into the main parser. There are other ways in which the parse could be enhanced but it would probably still be easier to do the unfolding as a separate step, like this.

Example:

```
BEGIN:VCARD
VERSION:3.0
PRODID:-//Sabre//Sabre VObject 4.5.4//EN
UID:95d439db-4c43-47d3-99d8-ca286c61a2aa
FN:Test Contact
ADR;TYPE=HOME:A very long address;Requiring multiple continuation lines;Tak
 ing several lines and;In a very very big city somewhere;in a huge ginormou
 s province;DSFH324324HFDSH 43432;of the land over the water\, up in the sk
 y and milions of light years away
END:VCARD

Unfolding cut 9 bytes
Regex for query term: ^FN([A-Za-z;=])*:(.*test.*)
Regex for search term: ADR(.*):(.*)
A very long address;Requiring multiple continuation lines;Taking several lines and;In a very very big city somewhere;in a huge ginormous province;DSFH324324HFDSH 43432;of the land over the water\, up in the sky and milions of light years away	Test Contact
```