### PR TITLE
Prefer https URLs in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Prerequisites
 -------------
 
 +  [C compiler](https://gcc.gnu.org/)
-+  [Curl](https://curl.haxx.se/libcurl/)
-+  [LibXML2](http://www.xmlsoft.org/)
++  [Curl](https://curl.se/libcurl/)
++  [LibXML2](https://gitlab.gnome.org/GNOME/libxml2/-/wikis/home)
 +  Optionally [GPGME](https://www.gnupg.org/software/gpgme/index.html)
 
 
@@ -80,10 +80,10 @@ The typical URL to query for various CardDav servers.
     `https://example.org/caldav.php/username/addresses`
 
 + [Owncloud](https://owncloud.org/)
-    `http://example.org/remote.php/carddav/addressbooks/username/contacts`
+    `https://example.org/remote.php/carddav/addressbooks/username/contacts`
 
 + [Nextcloud](https://nextcloud.com/)
-    `http://example.org/remote.php/dav/addressbooks/users/username/contacts`
+    `https://example.org/remote.php/dav/addressbooks/users/username/contacts`
 
 + [Gmail](https://gmail.com/)
     `https://www.googleapis.com/carddav/v1/principals/username@example.com/lists/default`

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Prerequisites
 +  [Curl](https://curl.se/libcurl/)
 +  [LibXML2](https://gitlab.gnome.org/GNOME/libxml2/-/wikis/home)
 +  Optionally [GPGME](https://www.gnupg.org/software/gpgme/index.html)
++  Optionally [Libsecret](https://wiki.gnome.org/Projects/Libsecret)
 
 
 Building / Installation

--- a/po/mcds.pot
+++ b/po/mcds.pot
@@ -175,7 +175,7 @@ msgstr ""
 #, c-format
 msgid ""
 "Copyright (C) %s Timothy Brown.\n"
-"License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl."
+"License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>"
 "html>\n"
 "This is free software: you are free to change and redistribute it.\n"
 "There is NO WARRANTY, to the extent permitted by law.\n"

--- a/src/carddav.c
+++ b/src/carddav.c
@@ -13,7 +13,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 

--- a/src/carddav.h
+++ b/src/carddav.h
@@ -12,7 +12,7 @@
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 

--- a/src/curl.c
+++ b/src/curl.c
@@ -12,7 +12,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 

--- a/src/curl.h
+++ b/src/curl.h
@@ -12,7 +12,7 @@
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 

--- a/src/decrypt.c
+++ b/src/decrypt.c
@@ -13,7 +13,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 

--- a/src/decrypt.h
+++ b/src/decrypt.h
@@ -12,7 +12,7 @@
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 

--- a/src/defs.h
+++ b/src/defs.h
@@ -12,7 +12,7 @@
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 

--- a/src/main.c
+++ b/src/main.c
@@ -13,7 +13,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 
@@ -339,7 +339,7 @@ print_version(void)
 	printf(_("%s (GNU %s) %s\n"), program_name(), PACKAGE, VERSION);
 	printf(_("\
 Copyright (C) %s Timothy Brown.\n\
-License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>\n\
+License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>\n\
 This is free software: you are free to change and redistribute it.\n\
 There is NO WARRANTY, to the extent permitted by law.\n\n"), "2019");
 	printf(_("Compiled on %s at %s:\n"

--- a/src/mem.c
+++ b/src/mem.c
@@ -12,7 +12,7 @@
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 

--- a/src/mem.h
+++ b/src/mem.h
@@ -12,7 +12,7 @@
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 

--- a/src/options.h
+++ b/src/options.h
@@ -12,7 +12,7 @@
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 

--- a/src/prompt.c
+++ b/src/prompt.c
@@ -12,7 +12,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 

--- a/src/prompt.h
+++ b/src/prompt.h
@@ -12,7 +12,7 @@
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 

--- a/src/rc.c
+++ b/src/rc.c
@@ -13,7 +13,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 

--- a/src/rc.h
+++ b/src/rc.h
@@ -12,7 +12,7 @@
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 

--- a/src/secret.c
+++ b/src/secret.c
@@ -12,7 +12,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 

--- a/src/secret.h
+++ b/src/secret.h
@@ -12,7 +12,7 @@
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 

--- a/src/vcard.c
+++ b/src/vcard.c
@@ -13,7 +13,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 

--- a/src/vcard.h
+++ b/src/vcard.h
@@ -12,7 +12,7 @@
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 

--- a/src/xml.c
+++ b/src/xml.c
@@ -12,7 +12,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 

--- a/src/xml.h
+++ b/src/xml.h
@@ -12,7 +12,7 @@
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 


### PR DESCRIPTION
Hi!

It was [suggested to me](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1085585#34) that I suggest to you to switch the `http:` URLs to `https:` in documentation files as a matter of best practice! What do you think?

Also, I wonder if you need `ABOUT-NLS` at all? It seems a bit dated and probably no use to anyone and I can't see anything to suggest it is required!

I think I've checked all the URLs in this PR work. I also updated a couple of addresses to where they currently redirect.