### PR TITLE
secret.c: appease -Wmissing-field-initializers

### DIFF
--- a/src/secret.c
+++ b/src/secret.c
@@ -55,8 +55,9 @@
 #define MCDS_SECRET_KEY_USER "user"
 
 static const SecretSchema mcds_secret_schema = {
-	MCDS_SECRET_SCHEMA_NAME, SECRET_SCHEMA_NONE,
-	{
+	.name = MCDS_SECRET_SCHEMA_NAME,
+	.flags = SECRET_SCHEMA_NONE,
+	.attributes = {
 		{ MCDS_SECRET_KEY_URL,  SECRET_SCHEMA_ATTRIBUTE_STRING },
 		{ MCDS_SECRET_KEY_USER, SECRET_SCHEMA_ATTRIBUTE_STRING },
 		{ "NULL", 0 }


### PR DESCRIPTION
Use C99 designators to avoid relying on assumptions about the order of fields in SecretSchema struct. This allows `mcds` to be built with `-Wextra`.

Fixes the following:
```    
gcc -DLOCALEDIR=\"/usr/local/share/locale\" -DHAVE_CONFIG_H   -I/usr/include/x86_64-linux-gnu -isystem /usr/include/mit-krb5 -I/usr/include/p11-kit-1  -I/usr/include/libxml2  -I/usr/include/libsecret-1 -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I/usr/include/sysprof-6 -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/gio-unix-2.0 -pthread     -Wextra -MT mcds-secret.o -MD -MP -MF .deps/mcds-secret.Tpo -c -o mcds-secret.o `test -f 'secret.c' || echo './'`secret.c
secret.c:64:1: warning: missing initializer for field ‘reserved’ of ‘SecretSchema’ [-Wmissing-field-initializers]
   64 | };
      | ^
In file included from /usr/include/libsecret-1/libsecret/secret-attributes.h:25,
                 from /usr/include/libsecret-1/libsecret/secret.h:22,
                 from secret.h:31,
                 from secret.c:47:
/usr/include/libsecret-1/libsecret/secret-schema.h:49:14: note: ‘reserved’ declared here
   49 |         gint reserved;
      |              ^~~~~~~~
```