### PR TITLE
Refresh README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ Prerequisites
 -------------
 
 +  [C compiler](https://gcc.gnu.org/)
-+  [Curl](https://curl.haxx.se/libcurl/)
-+  [LibXML2](http://www.xmlsoft.org/)
++  [Curl](https://curl.se/libcurl/)
++  [LibXML2](https://gitlab.gnome.org/GNOME/libxml2/-/wikis/home)
 +  Optionally [GPGME](https://www.gnupg.org/software/gpgme/index.html)
++  Optionally [Libsecret](https://wiki.gnome.org/Projects/Libsecret)
 
 
 Building / Installation
@@ -80,10 +81,10 @@ The typical URL to query for various CardDav servers.
     `https://example.org/caldav.php/username/addresses`
 
 + [Owncloud](https://owncloud.org/)
-    `http://example.org/remote.php/carddav/addressbooks/username/contacts`
+    `https://example.org/remote.php/carddav/addressbooks/username/contacts`
 
 + [Nextcloud](https://nextcloud.com/)
-    `http://example.org/remote.php/dav/addressbooks/users/username/contacts`
+    `https://example.org/remote.php/dav/addressbooks/users/username/contacts`
 
 + [Gmail](https://gmail.com/)
     `https://www.googleapis.com/carddav/v1/principals/username@example.com/lists/default`


### PR DESCRIPTION
Uses the current canonical link for the prerequisites, adds missing libsecret reference and uses https for example CardDAV server links.

Replaces #40.