### PR TITLE
Pass boolean options to libcurl as long type

### DIFF
--- a/src/curl.c
+++ b/src/curl.c
@@ -66,7 +66,7 @@ cinit(CURL **hdl)
 		warnx(_("Unable to initialize curl handle."));
 		return(EXIT_FAILURE);
 	}
-	if (curl_easy_setopt(*hdl, CURLOPT_VERBOSE, options.verbose)) {
+	if (curl_easy_setopt(*hdl, CURLOPT_VERBOSE, (long) options.verbose)) {
 		warnx(_("Unable to set curls verbose option."));
 		return(EXIT_FAILURE);
 	}
@@ -74,7 +74,7 @@ cinit(CURL **hdl)
 		warnx(_("Unable to set curls URL."));
 		return(EXIT_FAILURE);
 	}
-	if (curl_easy_setopt(*hdl, CURLOPT_SSL_VERIFYPEER, options.verify)) {
+	if (curl_easy_setopt(*hdl, CURLOPT_SSL_VERIFYPEER, (long) options.verify)) {
 		warnx(_("Unable to set curls SSL verification."));
 		return(EXIT_FAILURE);
 	}
@@ -88,7 +88,7 @@ cinit(CURL **hdl)
 			return(EXIT_FAILURE);
 		}
 	} else {
-		if (curl_easy_setopt(*hdl, CURLOPT_NETRC, options.netrc)) {
+		if (curl_easy_setopt(*hdl, CURLOPT_NETRC, (long) options.netrc)) {
 			warnx(_("Unable to set curls .netrc option."));
 			return(EXIT_FAILURE);
 		}


### PR DESCRIPTION
Fixes a problem showing up in Ubuntu Resolute Raccoon package builds on some architectures, such as amd64, when int types are passed in:

```
In function ‘cinit’,
    inlined from ‘main’ at main.c:138:6:
curl.c:69:13: error: call to ‘Wcurl_easy_setopt_err_long’ declared with attribute warning: curl_easy_setopt expects a long argument [-Werror=attribute-warning]
   69 |         if (curl_easy_setopt(*hdl, CURLOPT_VERBOSE, options.verbose)) {
      |             ^
curl.c:77:13: error: call to ‘Wcurl_easy_setopt_err_long’ declared with attribute warning: curl_easy_setopt expects a long argument [-Werror=attribute-warning]
   77 |         if (curl_easy_setopt(*hdl, CURLOPT_SSL_VERIFYPEER, options.verify)) {
      |             ^
curl.c:91:21: error: call to ‘Wcurl_easy_setopt_err_long’ declared with attribute warning: curl_easy_setopt expects a long argument [-Werror=attribute-warning]
   91 |                 if (curl_easy_setopt(*hdl, CURLOPT_NETRC, options.netrc)) {
      |                     ^
lto1: all warnings being treated as errors
```

https://launchpadlibrarian.net/833438792/buildlog_ubuntu-resolute-amd64.mcds_1.9-4_BUILDING.txt.gz

The warning seems to be correct, based on the man page. This error could cause incorrect behaviour and may have been the cause of instability in the Debian autopkgtest _.netrc_ authentication test, which occasionally failed inexplicably.

I didn't work out how to trigger this warning in a standalone build or on Debian but did reproduce building the package in an Ubuntu development VM and tested the fix there.