### PR TITLE
gcc-16: eliminate line counter that is never read

### DIFF
--- a/src/rc.c
+++ b/src/rc.c
@@ -62,7 +62,6 @@ read_rc(const char *file)
 {
 
 	int i  = 0;                    /* Temporary loop indexer */
-	int ln = 0;                    /* Line number */
 	int len = 0;                   /* String length */
 	char *home = NULL;             /* Home directory */
 	char *pfile = NULL;            /* Password file */
@@ -116,7 +115,6 @@ read_rc(const char *file)
 	}
 
 	while (fgets(line, LINE_MAX, ifd) != NULL) {
-		++ln;
 		lptr = line;
 		i = 0;
 		if (line[0] != '\n' && line[0] != '#') {


### PR DESCRIPTION
Avoids warning when -Wunused-but-set-variable >= 2.

Fixes #44